### PR TITLE
Activate dev tools only in development

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "freeman",
-  "version": "0.8.5",
+  "version": "0.8.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3872,7 +3872,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.1.1",
@@ -4577,7 +4578,8 @@
         "safe-buffer": {
           "version": "5.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "semver": {
           "version": "5.3.0",
@@ -4660,6 +4662,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2888,9 +2888,9 @@
       }
     },
     "electron-devtools-installer": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/electron-devtools-installer/-/electron-devtools-installer-2.2.3.tgz",
-      "integrity": "sha512-KFVP2lt3guvhXsUKE3YxbddMOJtpdvTsWfloV/8395Df5Td9Z+YvNl8LFW864mVqdDJsiy2qQ8y95NT5C+avSA==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/electron-devtools-installer/-/electron-devtools-installer-2.2.4.tgz",
+      "integrity": "sha512-b5kcM3hmUqn64+RUcHjjr8ZMpHS2WJ5YO0pnG9+P/RTdx46of/JrEjuciHWux6pE+On6ynWhHJF53j/EDJN0PA==",
       "requires": {
         "7zip": "0.0.6",
         "cross-unzip": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "electron-debug": "^2.0.0",
     "electron-devtools-installer": "^2.2.3",
     "electron-fswin": "^2.18.2",
+    "electron-is-dev": "^0.3.0",
     "electron-log": "^2.2.13",
     "electron-window-state": "^4.1.1",
     "file-icons-js": "github:websemantics/file-icons-js",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "electron-about-window": "^1.10.0",
     "electron-config": "^1.0.0",
     "electron-debug": "^2.0.0",
-    "electron-devtools-installer": "^2.2.3",
+    "electron-devtools-installer": "^2.2.4",
     "electron-fswin": "^2.18.2",
     "electron-is-dev": "^0.3.0",
     "electron-log": "^2.2.13",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freeman",
   "productName": "FreeMAN",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "A free, extensible, cross-platform file manager for power users",
   "main": "app/main.js",
   "build": {

--- a/src/main/arguments/ArgumentsParser.ts
+++ b/src/main/arguments/ArgumentsParser.ts
@@ -12,6 +12,7 @@ export default {
      */
     parse(args: string[]): IParsedArguments {
         const result: IParsedArguments = {
+            openInDevelopment: false,
             verbose: false,
             version: false
         };
@@ -21,6 +22,8 @@ export default {
                 result.version = true;
             } else if (verboseRequested(arg)) {
                 result.verbose = true;
+            } else if (openInDevelopmentRequested(arg)) {
+                result.openInDevelopment = true;
             }
         });
 
@@ -48,4 +51,8 @@ function verboseRequested(arg: string): boolean {
  */
 function versionRequested(arg: string): boolean {
     return arg === "--version" || arg === "-v";
+}
+
+function openInDevelopmentRequested(arg: string): boolean {
+    return arg === "--dev" || arg === "-d";
 }

--- a/src/main/arguments/IParsedArguments.ts
+++ b/src/main/arguments/IParsedArguments.ts
@@ -2,6 +2,7 @@
 interface IParsedArguments {
     verbose: boolean;
     version: boolean;
+    openInDevelopment: boolean;
 }
 
 export default IParsedArguments;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,11 +6,6 @@ import { ArgumentsParser } from "arguments";
 import Utils from "Utils";
 import { FreemanWindow } from "widgets";
 
-const isDev = require("electron-is-dev");
-if (isDev) {
-    require("electron-debug")({ enabled: true });
-}
-
 let mainWindow: FreemanWindow | null = null;
 
 const parsedArguments = ArgumentsParser.parse(process.argv);
@@ -23,6 +18,11 @@ if (parsedArguments.version) {
 if (parsedArguments.verbose) {
     process.env.VERBOSE = "1";
     Utils.trace("Running application in verbose mode");
+}
+
+const isDev = require("electron-is-dev");
+if (parsedArguments.openInDevelopment || isDev) {
+    require("electron-debug")({ enabled: true });
 }
 
 app.on("window-all-closed", () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,11 +1,15 @@
 import { app, dialog, ipcMain, Menu } from "electron";
 import windowStateKeeper from "electron-window-state";
 import "reflect-metadata";
-require("electron-debug")({ enabled: true });
 
 import { ArgumentsParser } from "arguments";
 import Utils from "Utils";
 import { FreemanWindow } from "widgets";
+
+const isDev = require("electron-is-dev");
+if (isDev) {
+    require("electron-debug")({ enabled: true });
+}
 
 let mainWindow: FreemanWindow | null = null;
 

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -19,12 +19,9 @@ import Utils from "Utils";
 
 import "styles/main.scss";
 
-const isDev = require("electron-is-dev");
-if (isDev) {
-    installExtension(REACT_DEVELOPER_TOOLS)
-        .then(name => log.info("Installed plugin", name))
-        .catch(error => log.error(error));
-}
+installExtension(REACT_DEVELOPER_TOOLS)
+    .then(name => log.info("Installed plugin", name))
+    .catch(error => log.error(error));
 
 if (remote.process.env.VERBOSE) {
     process.env.VERBOSE = "1";

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -19,9 +19,12 @@ import Utils from "Utils";
 
 import "styles/main.scss";
 
-installExtension(REACT_DEVELOPER_TOOLS)
-    .then(name => log.info("Installed plugin", name))
-    .catch(error => log.error(error));
+const isDev = require("electron-is-dev");
+if (isDev) {
+    installExtension(REACT_DEVELOPER_TOOLS)
+        .then(name => log.info("Installed plugin", name))
+        .catch(error => log.error(error));
+}
 
 if (remote.process.env.VERBOSE) {
     process.env.VERBOSE = "1";

--- a/test/main/arguments/ArgumentsParser.test.ts
+++ b/test/main/arguments/ArgumentsParser.test.ts
@@ -32,5 +32,19 @@ describe("ArgumentsParser's", () => {
 
             expect(result.version).to.be.true;
         });
+
+        it("parses '--dev' flag successfully", () => {
+            const args = ["--dev"];
+            const result = ArgumentsParser.parse(args);
+
+            expect(result.openInDevelopment).to.be.true;
+        });
+
+        it("parses '-d' flag successfully", () => {
+            const args = ["-d"];
+            const result = ArgumentsParser.parse(args);
+
+            expect(result.openInDevelopment).to.be.true;
+        });
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please do not create a Pull Request without creating an issue first.
Any change needs to be discussed before proceeding.
Failure to do so may result in the rejection of the pull request. -->

## Description

- `electron-debug` module only loaded when `electron-is-dev === true`
- Provided command-line argument that can be used for loading packaged app in development mode

<!--- Describe your changes in detail, then fill in the checklist below -->

- [x] I have followed the [Contributing Guidlines](CONTRIBUTING.md)
- [x] There are no open pull requests for the same update
- [x] My pull request targets the `develop` branch of the FreeMAN repository
- [x] I have incremented the patch segment of the version number

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here. Note that there should only be one
linked issue -->
<!--- Please ensure you have marked items in any checklist in the related issue
that have been resolved by code in this pull request -->

This pull request closes #25 

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran -->
<!--- When done, fill in the checklist -->

- Tested manually on Linux in both development and production (packaged) environments.

- [x] Added tests
- [x] Ran `npm run lint` successfully
- [x] Ran `npm run test` successfully